### PR TITLE
[Feat] 각 상권분석 데이터 파일 병합 및 정제

### DIFF
--- a/eda/code/data_merge.ipynb
+++ b/eda/code/data_merge.ipynb
@@ -1,0 +1,358 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import os\n",
+    "\n",
+    "# eda/code -> eda/data\n",
+    "data_path = '../data/'\n",
+    "output_path = '../data/merged_data.csv'\n",
+    "\n",
+    "# ---------------------------------------\n",
+    "# 1. 모든 CSV 파일 읽기 (8개)\n",
+    "# ---------------------------------------\n",
+    "commercial_change = pd.read_csv(os.path.join(data_path, 'commercial_change_data.csv')) # 상권변화\n",
+    "floating_population = pd.read_csv(os.path.join(data_path, 'floating_population.csv')) # 유동인구\n",
+    "income_consumption = pd.read_csv(os.path.join(data_path, 'income_consumption_data.csv')) # 소득\n",
+    "rent = pd.read_csv(os.path.join(data_path, 'rent_data.csv')) # 임대료\n",
+    "resident_population = pd.read_csv(os.path.join(data_path, 'resident_population.csv')) # 주거인구\n",
+    "seling_count = pd.read_csv(os.path.join(data_path, 'seling_count_data.csv')) \n",
+    "# 매출\n",
+    "stores = pd.read_csv(os.path.join(data_path, 'stores_data.csv')) # 점포\n",
+    "working_population = pd.read_csv(os.path.join(data_path, 'working_population_data.csv')) # 직장인구\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(64715, 56)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# ---------------------------------------\n",
+    "# 2. 업종 데이터 있는 파일 병합 (stores + seling_count)\n",
+    "# ---------------------------------------\n",
+    "service_df = pd.merge(stores, seling_count, on=['기준_년분기_코드', '자치구_코드_명', '서비스_업종_코드_명'], how='outer')\n",
+    "\n",
+    "service_df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(650, 88)"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# ---------------------------------------\n",
+    "# 3. 자치구 데이터 병합 (나머지 6개)\n",
+    "# ---------------------------------------\n",
+    "district_dfs = [commercial_change, floating_population, income_consumption, rent, resident_population, working_population] # 업종없는 데이터\n",
+    "# 첫 번째 데이터프레임 기준으로 초기화 - commercial_change\n",
+    "merged_district_df = district_dfs[0]\n",
+    "# 나머지 데이터프레임 순차적으로 병합\n",
+    "for df in district_dfs[1:]:\n",
+    "    merged_district_df = pd.merge(merged_district_df, df, on=['기준_년분기_코드', '자치구_코드_명'], how='outer')\n",
+    "    \n",
+    "merged_district_df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(64715, 142)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# ---------------------------------------\n",
+    "# 4. 최종 병합 (Left Join) - 서비스 업종 있는 df + 없는 df 병합\n",
+    "# ---------------------------------------\n",
+    "final_df = pd.merge(service_df, merged_district_df, on=['기준_년분기_코드', '자치구_코드_명'], how='left')\n",
+    "\n",
+    "final_df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "최종 데이터셋 크기: (39975, 137)\n",
+      "최종 데이터셋 컬럼 수: 137\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ---------------------------------------\n",
+    "# 5. 컬럼 제거 및 결과 저장\n",
+    "# ---------------------------------------\n",
+    "# 혹시 unnamed column 대비해서 drop\n",
+    "unnamed_cols = [col for col in final_df.columns if 'Unnamed' in col]\n",
+    "final_df.drop(columns=unnamed_cols, inplace=True)\n",
+    "\n",
+    "# seling_count에 없는 업종 제거\n",
+    "final_df.dropna(inplace=True)\n",
+    "\n",
+    "# csv로 저장: eda/data/merged_data.csv\n",
+    "final_df.to_csv(output_path, index=False)\n",
+    "\n",
+    "print(f\"최종 데이터셋 크기: {final_df.shape}\")\n",
+    "print(f\"최종 데이터셋 컬럼 수: {len(final_df.columns)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# DataFrame 컬럼 전체 출력\n",
+    "pd.set_option('display.max_columns', None)\n",
+    "\n",
+    "# DataFrame 행 전체 출력\n",
+    "pd.set_option('display.max_rows', None)\n",
+    "\n",
+    "# DataFrame의 최대 출력 너비 설정\n",
+    "pd.set_option('display.max_colwidth', None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Index: 39975 entries, 1 to 64713\n",
+      "Columns: 137 entries, 기준_년분기_코드 to 여성연령대_60_이상_직장_인구_수\n",
+      "dtypes: float64(132), int64(2), object(3)\n",
+      "memory usage: 42.1+ MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "final_df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "기준_년분기_코드              0\n",
+       "자치구_코드_명               0\n",
+       "서비스_업종_코드_명            0\n",
+       "점포_수                   0\n",
+       "유사_업종_점포_수             0\n",
+       "개업_률                   0\n",
+       "개업_점포_수                0\n",
+       "폐업_률                   0\n",
+       "폐업_점포_수                0\n",
+       "프랜차이즈_점포_수             0\n",
+       "당월_매출_금액               0\n",
+       "당월_매출_건수               0\n",
+       "월요일_매출_금액              0\n",
+       "화요일_매출_금액              0\n",
+       "수요일_매출_금액              0\n",
+       "목요일_매출_금액              0\n",
+       "금요일_매출_금액              0\n",
+       "토요일_매출_금액              0\n",
+       "일요일_매출_금액              0\n",
+       "시간대_00_06_매출_금액        0\n",
+       "시간대_06_11_매출_금액        0\n",
+       "시간대_11_14_매출_금액        0\n",
+       "시간대_14_17_매출_금액        0\n",
+       "시간대_17_21_매출_금액        0\n",
+       "시간대_21_24_매출_금액        0\n",
+       "남성_매출_금액               0\n",
+       "여성_매출_금액               0\n",
+       "연령대_10_매출_금액           0\n",
+       "연령대_20_매출_금액           0\n",
+       "연령대_30_매출_금액           0\n",
+       "연령대_40_매출_금액           0\n",
+       "연령대_50_매출_금액           0\n",
+       "연령대_60_이상_매출_금액        0\n",
+       "월요일_매출_건수              0\n",
+       "화요일_매출_건수              0\n",
+       "수요일_매출_건수              0\n",
+       "목요일_매출_건수              0\n",
+       "금요일_매출_건수              0\n",
+       "토요일_매출_건수              0\n",
+       "일요일_매출_건수              0\n",
+       "시간대_건수~06_매출_건수        0\n",
+       "시간대_건수~11_매출_건수        0\n",
+       "시간대_건수~14_매출_건수        0\n",
+       "시간대_건수~17_매출_건수        0\n",
+       "시간대_건수~21_매출_건수        0\n",
+       "시간대_건수~24_매출_건수        0\n",
+       "남성_매출_건수               0\n",
+       "여성_매출_건수               0\n",
+       "연령대_10_매출_건수           0\n",
+       "연령대_20_매출_건수           0\n",
+       "연령대_30_매출_건수           0\n",
+       "연령대_40_매출_건수           0\n",
+       "연령대_50_매출_건수           0\n",
+       "연령대_60_이상_매출_건수        0\n",
+       "상권_변화_지표               0\n",
+       "운영_영업_개월_평균            0\n",
+       "폐업_영업_개월_평균            0\n",
+       "서울시_운영_영업_개월_평균        0\n",
+       "서울시_폐업_영업_개월_평균        0\n",
+       "총_유동인구_수               0\n",
+       "남성_유동인구_수              0\n",
+       "여성_유동인구_수              0\n",
+       "연령대_10_유동인구_수          0\n",
+       "연령대_20_유동인구_수          0\n",
+       "연령대_30_유동인구_수          0\n",
+       "연령대_40_유동인구_수          0\n",
+       "연령대_50_유동인구_수          0\n",
+       "연령대_60_이상_유동인구_수       0\n",
+       "시간대_00_06_유동인구_수       0\n",
+       "시간대_06_11_유동인구_수       0\n",
+       "시간대_11_14_유동인구_수       0\n",
+       "시간대_14_17_유동인구_수       0\n",
+       "시간대_17_21_유동인구_수       0\n",
+       "시간대_21_24_유동인구_수       0\n",
+       "월요일_유동인구_수             0\n",
+       "화요일_유동인구_수             0\n",
+       "수요일_유동인구_수             0\n",
+       "목요일_유동인구_수             0\n",
+       "금요일_유동인구_수             0\n",
+       "토요일_유동인구_수             0\n",
+       "일요일_유동인구_수             0\n",
+       "월_평균_소득_금액             0\n",
+       "지출_총_금액                0\n",
+       "식료품_지출_총금액             0\n",
+       "의류_신발_지출_총금액           0\n",
+       "생활용품_지출_총금액            0\n",
+       "의료비_지출_총금액             0\n",
+       "교통_지출_총금액              0\n",
+       "교육_지출_총금액              0\n",
+       "유흥_지출_총금액              0\n",
+       "여가_문화_지출_총금액           0\n",
+       "기타_지출_총금액              0\n",
+       "음식_지출_총금액              0\n",
+       "전체임대료                  0\n",
+       "총_상주인구_수               0\n",
+       "남성_상주인구_수              0\n",
+       "여성_상주인구_수              0\n",
+       "연령대_10_미만_상주인구_수       0\n",
+       "연령대_20_상주인구_수          0\n",
+       "연령대_30_상주인구_수          0\n",
+       "연령대_40_상주인구_수          0\n",
+       "연령대_50_상주인구_수          0\n",
+       "연령대_60_이상_상주인구_수       0\n",
+       "남성연령대_10_상주인구_수        0\n",
+       "남성연령대_20_상주인구_수        0\n",
+       "남성연령대_30_상주인구_수        0\n",
+       "남성연령대_40_상주인구_수        0\n",
+       "남성연령대_50_상주인구_수        0\n",
+       "남성연령대_60_이상_상주인구_수     0\n",
+       "여성연령대_10_상주인구_수        0\n",
+       "여성연령대_20_상주인구_수        0\n",
+       "여성연령대_30_상주인구_수        0\n",
+       "여성연령대_40_상주인구_수        0\n",
+       "여성연령대_50_상주인구_수        0\n",
+       "여성연령대_60_이상_상주인구_수     0\n",
+       "총_가구_수                 0\n",
+       "총_직장인구_수               0\n",
+       "남성_직장인구_수              0\n",
+       "여성_직장인구_수              0\n",
+       "연령대_10_직장인구_수          0\n",
+       "연령대_20_직장인구_수          0\n",
+       "연령대_30_직장인구_수          0\n",
+       "연령대_40_직장인구_수          0\n",
+       "연령대_50_직장인구_수          0\n",
+       "연령대_60_이상_직장인구_수       0\n",
+       "남성연령대_10_직장_인구_수       0\n",
+       "남성연령대_20_직장_인구_수       0\n",
+       "남성연령대_30_직장_인구_수       0\n",
+       "남성연령대_40_직장_인구_수       0\n",
+       "남성연령대_50_직장_인구_수       0\n",
+       "남성연령대_60_이상_직장_인구_수    0\n",
+       "여성연령대_10_직장_인구_수       0\n",
+       "여성연령대_20_직장_인구_수       0\n",
+       "여성연령대_30_직장_인구_수       0\n",
+       "여성연령대_40_직장_인구_수       0\n",
+       "여성연령대_50_직장_인구_수       0\n",
+       "여성연령대_60_이상_직장_인구_수    0\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "final_df.isna().sum()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ml_env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.23"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION


## What to do

 - [x] 8개로 분리된 상권분석 CSV 파일을 단일 파일(merged_data.csv)로 병합
 - [x] 데이터 병합 과정을 재현 가능하도록 data_merge.ipynb 노트북 스크립트 작성

## Description

- 목표
  - 폐업률 예측 ML/DL 모델 학습에 사용될 통합 데이터셋 구축.

- 병합 전략
    - 각각의 파일이 가진 데이터의 레벨(업종별/자치구별)을 고려하여 병합을 진행.

   1. 기준 데이터 설정: stores_data.csv(점포 정보)와 seling_count_data.csv(매출 정보)를 서비스_업종_코드_명을 포함한 키로 병합하여      업종 Level의 기본 데이터셋 구성.

   2. 특성 데이터 추가: 나머지 6개 파일(유동인구, 상주인구, 소득, 임대료 등)에 포함된 자치구 Level 데이터를 위에서 만든 기본 데이터셋에 left join.
  
   3. 결과: 각 업종 데이터(행)가 해당 업종이 속한 자치구의 환경적 특징(유동인구, 임대료 등)을 모두 특성(컬럼)으로 갖도록 구성.

  주요 발견 및 처리
   - 병합 과정에서 stores_data.csv에만 존재하고 seling_count_data.csv에는 없는 업종이 37개 발견.
   - 이로 인해 최종 merged_data.csv 파일에서 해당 37개 업종은 매출 관련 컬럼들이 빈 값(NaN)으로 표시되는 문제 발생.
   - 이에 따라 서로 교집합되는 업종(63종)만 이용하도록 매출 정보가 없는 업종 drop하여 병합. 

- 최종 데이터셋 크기: (39975, 137)
- 최종 데이터셋 컬럼 수: 137